### PR TITLE
Implement full status reporting

### DIFF
--- a/pvpn/natpmp.py
+++ b/pvpn/natpmp.py
@@ -87,3 +87,12 @@ def start_forward(iface: str) -> int:
     t.start()
 
     return pub_port
+
+
+def get_public_port(iface: str, internal_port: int) -> int:
+    """Query the current NAT-PMP mapping and return the public port."""
+    try:
+        gateway = _get_vpn_gateway(iface)
+    except Exception:
+        return 0
+    return _request_mapping(gateway, internal_port)

--- a/pvpn/protonvpn.py
+++ b/pvpn/protonvpn.py
@@ -224,13 +224,32 @@ def disconnect(cfg: Config, args):
     print("✅ Disconnected")
 
 def status(cfg: Config):
-    """
-    Display current VPN and qBittorrent status.
-    """
-    from pvpn.wireguard import status as wg_status
-    wg_status()
-    # Further implementation can query qBittorrent API for port + torrent count
-    print("qBittorrent and routing status not yet fully implemented")
+    """Display WireGuard, routing, and qBittorrent status."""
+    from pvpn.wireguard import get_active_iface, get_dns_servers
+    from pvpn.routing import killswitch_status
+    from pvpn.natpmp import get_public_port
+    from pvpn.qbittorrent import get_listen_port
+
+    iface = get_active_iface()
+    print(f"Interface: {iface if iface else 'none'}")
+
+    dns = get_dns_servers()
+    if dns:
+        print("DNS: " + ", ".join(dns))
+    else:
+        print("DNS: unknown")
+
+    ks = killswitch_status()
+    print(f"Kill-switch: {'enabled' if ks else 'disabled'}")
+
+    pub_port = get_public_port(iface, cfg.qb_port) if iface else 0
+    if pub_port:
+        print(f"Forwarded port: {pub_port}")
+    else:
+        print("Forwarded port: none")
+
+    qb_port = get_listen_port(cfg)
+    print(f"qBittorrent port: {qb_port}")
 
 def list_servers(cfg: Config, args):
     """

--- a/pvpn/routing.py
+++ b/pvpn/routing.py
@@ -51,6 +51,17 @@ def disable_killswitch():
     else:
         logging.warning("No iptables backup found; cannot disable kill-switch")
 
+
+def killswitch_status() -> bool:
+    """Return True if the kill-switch appears active."""
+    try:
+        rules = run_cmd("iptables -S OUTPUT")
+        if "-P OUTPUT DROP" in rules and os.path.exists("/etc/pvpn-iptables.bak"):
+            return True
+    except Exception as e:
+        logging.error(f"Failed to check kill-switch: {e}")
+    return False
+
 def _ensure_chain():
     """
     Ensure the custom mangle chain exists and is hooked into OUTPUT.

--- a/pvpn/wireguard.py
+++ b/pvpn/wireguard.py
@@ -132,3 +132,30 @@ def status():
         print(open(RESOLV_CONF).read())
     except Exception as e:
         logging.error(f"Failed to read {RESOLV_CONF}: {e}")
+
+
+def get_active_iface() -> str:
+    """Return the first active pvpn-managed WireGuard interface name or an empty string."""
+    try:
+        out = run_cmd("wg show interfaces").strip()
+        for iface in out.split():
+            if iface.startswith("wgp"):
+                return iface
+    except Exception as e:
+        logging.debug(f"Failed to get active WireGuard interface: {e}")
+    return ""
+
+
+def get_dns_servers() -> list:
+    """Return a list of DNS resolvers from /etc/resolv.conf."""
+    servers = []
+    try:
+        with open(RESOLV_CONF) as f:
+            for line in f:
+                if line.strip().startswith("nameserver"):
+                    parts = line.split()
+                    if len(parts) >= 2:
+                        servers.append(parts[1])
+    except Exception as e:
+        logging.error(f"Failed to read {RESOLV_CONF}: {e}")
+    return servers

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,3 @@
+import os
+import sys
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))

--- a/tests/test_status.py
+++ b/tests/test_status.py
@@ -1,0 +1,19 @@
+import pvpn.protonvpn as pv
+from pvpn.config import Config
+
+
+def test_status_reports_all(monkeypatch, capsys):
+    cfg = Config()
+    monkeypatch.setattr('pvpn.wireguard.get_active_iface', lambda: 'wgpTEST0')
+    monkeypatch.setattr('pvpn.wireguard.get_dns_servers', lambda: ['1.1.1.1', '9.9.9.9'])
+    monkeypatch.setattr('pvpn.routing.killswitch_status', lambda: True)
+    monkeypatch.setattr('pvpn.natpmp.get_public_port', lambda iface, port: 12345)
+    monkeypatch.setattr('pvpn.qbittorrent.get_listen_port', lambda cfg: 6881)
+
+    pv.status(cfg)
+    out = capsys.readouterr().out
+    assert 'Interface: wgpTEST0' in out
+    assert 'DNS: 1.1.1.1, 9.9.9.9' in out
+    assert 'Kill-switch: enabled' in out
+    assert 'Forwarded port: 12345' in out
+    assert 'qBittorrent port: 6881' in out


### PR DESCRIPTION
## Summary
- Implement comprehensive `pvpn status` output covering interface, DNS, kill-switch, forwarded port and qBittorrent port
- Add helper utilities for WireGuard interface/DNS detection, NAT-PMP port lookup, kill-switch status, and qBittorrent port query
- Add tests ensuring status reports all details

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ba923e6ff883298140fff9a762379e