### PR TITLE
Add VPN connection monitor and auto-reconnect

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,8 +32,9 @@
 - **NAT-PMP Port Forwarding**: `natpmpc`-based mapping & automatic lease refresh  
 - **qBittorrent-nox Integration**: sync listen-port via WebUI API or config-file fallback; resume stalled torrents  
 - **Kill-Switch**: reversible iptables DROP of all non-VPN traffic (`--ks`)  
-- **Split-Tunnel**: bypass VPN for specific processes, PIDs, or IPs (`pvpn tunnel`)  
-- **Modular init**: `pvpn init [--proton|--qb|--tunnel|--network]` for targeted or full setup  
+- **Split-Tunnel**: bypass VPN for specific processes, PIDs, or IPs (`pvpn tunnel`)
+- **Modular init**: `pvpn init [--proton|--qb|--tunnel|--network]` for targeted or full setup
+- **Background Monitor**: auto-reconnect on repeated ping failures or high latency
 
 ---
 
@@ -127,6 +128,11 @@ threshold_default = 60
 
 [tunnel]
 tunnel_json_path = /home/pi/.pvpn-cli/pvpn/tunnel.json
+
+[monitor]
+interval = 60
+failures = 3
+latency_threshold = 500
 ```
 
 ### 3. Example `tunnel.json`
@@ -137,6 +143,21 @@ tunnel_json_path = /home/pi/.pvpn-cli/pvpn/tunnel.json
   "pids": [12345],
   "ips": ["203.0.113.0/24"]
 }
+```
+
+### 4. Background Monitor
+
+After `pvpn connect` succeeds, a background thread periodically pings the
+connected server. When `failures` consecutive checks either time out or exceed
+`latency_threshold` (ms), the client automatically runs a disconnect followed
+by a new connection to rotate servers. Control these values in the `[monitor]`
+section of `config.ini`:
+
+```
+[monitor]
+interval = 60            # seconds between checks
+failures = 3             # consecutive bad pings before reconnect
+latency_threshold = 500  # milliseconds considered too slow
 ```
 
 ---

--- a/pvpn/config.py
+++ b/pvpn/config.py
@@ -39,6 +39,11 @@ class Config:
         self.network_dns_default = True
         self.network_threshold_default = 60
 
+        # Monitoring defaults
+        self.monitor_interval = 60
+        self.monitor_failures = 3
+        self.monitor_latency_threshold = 500
+
         # Load existing config if available
         try:
             loaded = Config.load(config_dir)
@@ -78,6 +83,12 @@ class Config:
                     cfg.network_ks_default = sec.getboolean('ks_default', cfg.network_ks_default)
                     cfg.network_dns_default = sec.getboolean('dns_default', cfg.network_dns_default)
                     cfg.network_threshold_default = sec.getint('threshold_default', cfg.network_threshold_default)
+                # Monitor defaults
+                if 'monitor' in cfg.parser:
+                    sec = cfg.parser['monitor']
+                    cfg.monitor_interval = sec.getint('interval', cfg.monitor_interval)
+                    cfg.monitor_failures = sec.getint('failures', cfg.monitor_failures)
+                    cfg.monitor_latency_threshold = sec.getint('latency_threshold', cfg.monitor_latency_threshold)
                 # Tunnel JSON path
                 if 'tunnel' in cfg.parser:
                     sec = cfg.parser['tunnel']
@@ -109,6 +120,11 @@ class Config:
             'ks_default': str(self.network_ks_default),
             'dns_default': str(self.network_dns_default),
             'threshold_default': str(self.network_threshold_default)
+        }
+        self.parser['monitor'] = {
+            'interval': str(self.monitor_interval),
+            'failures': str(self.monitor_failures),
+            'latency_threshold': str(self.monitor_latency_threshold)
         }
         self.parser['tunnel'] = {
             'tunnel_json_path': str(self.tunnel_json_path)

--- a/pvpn/monitor.py
+++ b/pvpn/monitor.py
@@ -1,0 +1,141 @@
+# pvpn/monitor.py
+
+"""Background connection monitoring for pvpn.
+
+This module spawns a daemon thread that periodically pings the current
+WireGuard peer. If the ping fails or exceeds a latency threshold a number
+of consecutive times, the VPN connection is cycled by invoking
+``protonvpn.disconnect`` followed by ``protonvpn.connect``.
+
+Configuration is sourced from :class:`pvpn.config.Config` via the following
+fields (with defaults shown)::
+
+    monitor_interval = 60           # seconds between checks
+    monitor_failures = 3            # consecutive bad pings before reconnect
+    monitor_latency_threshold = 500 # milliseconds considered too slow
+
+"""
+
+from __future__ import annotations
+
+import logging
+import subprocess
+import threading
+import time
+from types import SimpleNamespace
+
+from pvpn.config import Config
+from pvpn import protonvpn
+
+
+def _get_endpoint_ip(iface: str) -> str | None:
+    """Return the endpoint IP for the first peer on ``iface``.
+
+    Uses ``wg show <iface> endpoints`` and parses the first line to obtain the
+    peer IP. Returns ``None`` if it cannot be determined.
+    """
+
+    try:
+        out = subprocess.check_output(
+            ["wg", "show", iface, "endpoints"], text=True, timeout=5
+        ).strip()
+        if not out:
+            return None
+        parts = out.split()
+        if len(parts) >= 2:
+            return parts[1].split(":")[0]
+    except Exception as exc:  # noqa: BLE001
+        logging.debug(f"monitor: failed to get endpoint for {iface}: {exc}")
+    return None
+
+
+def _ping(ip: str) -> float | None:
+    """Ping ``ip`` once and return the average RTT in ms.
+
+    Returns ``None`` on timeout or other error.
+    """
+
+    try:
+        out = subprocess.check_output(
+            ["ping", "-c", "1", "-W", "2", ip],
+            stderr=subprocess.DEVNULL,
+            timeout=5,
+            text=True,
+        )
+        stats = next((l for l in out.splitlines() if "rtt min/avg" in l), "")
+        return float(stats.split("/")[4]) if stats else None
+    except Exception:  # noqa: BLE001
+        return None
+
+
+def _monitor_loop(cfg: Config, iface: str) -> None:
+    """Worker loop run in a background thread."""
+
+    interval = cfg.monitor_interval
+    failure_limit = cfg.monitor_failures
+    latency_limit = cfg.monitor_latency_threshold
+    failures = 0
+
+    logging.info(
+        "Starting monitor on %s (interval=%ss, failures=%s, latency=%sms)",
+        iface,
+        interval,
+        failure_limit,
+        latency_limit,
+    )
+
+    while True:
+        time.sleep(interval)
+        ip = _get_endpoint_ip(iface)
+        if not ip:
+            logging.warning("monitor: could not determine peer endpoint")
+            failures += 1
+        else:
+            latency = _ping(ip)
+            if latency is None or latency > latency_limit:
+                logging.warning(
+                    "monitor: ping failed or high latency (%s ms) to %s", latency, ip
+                )
+                failures += 1
+            else:
+                logging.debug("monitor: latency %sms to %s", latency, ip)
+                failures = 0
+
+        if failures >= failure_limit:
+            logging.warning("monitor: threshold reached, rotating server")
+            # minimal args for disconnect/connect
+            disc_args = SimpleNamespace(ks=None)
+            conn_args = SimpleNamespace(
+                cc=None,
+                sc=False,
+                p2p=False,
+                threshold=None,
+                fastest=None,
+                latency_cutoff=None,
+                dns=None,
+                ks=None,
+            )
+            try:
+                protonvpn.disconnect(cfg, disc_args)
+            except Exception as exc:  # noqa: BLE001
+                logging.error(f"monitor: disconnect failed: {exc}")
+            try:
+                protonvpn.connect(cfg, conn_args)
+            except Exception as exc:  # noqa: BLE001
+                logging.error(f"monitor: reconnect failed: {exc}")
+            return
+
+
+def start_monitor(cfg: Config, iface: str) -> threading.Thread:
+    """Spawn the monitoring thread and return it.
+
+    The thread is marked as daemon so it won't block process exit.
+    """
+
+    thread = threading.Thread(target=_monitor_loop, args=(cfg, iface), daemon=True)
+    thread.start()
+    return thread
+
+
+__all__ = ["start_monitor"]
+

--- a/pvpn/protonvpn.py
+++ b/pvpn/protonvpn.py
@@ -200,6 +200,9 @@ def connect(cfg: Config, args):
     from pvpn.qbittorrent import update_port
     update_port(cfg, pub_port)
 
+    from pvpn.monitor import start_monitor
+    start_monitor(cfg, iface)
+
     print(f"✅ Connected: {server['Name']} on {iface}, forwarded port {pub_port}")
 
 def disconnect(cfg: Config, args):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -13,6 +13,9 @@ def test_config_save_load(tmp_path):
     cfg.proton_user = "alice"
     cfg.proton_pass = "secret"
     cfg.qb_port = 12345
+    cfg.monitor_interval = 30
+    cfg.monitor_failures = 5
+    cfg.monitor_latency_threshold = 800
     cfg.save()
 
     # Load fresh and verify
@@ -20,6 +23,9 @@ def test_config_save_load(tmp_path):
     assert cfg2.proton_user == "alice"
     assert cfg2.proton_pass == "secret"
     assert cfg2.qb_port == 12345
+    assert cfg2.monitor_interval == 30
+    assert cfg2.monitor_failures == 5
+    assert cfg2.monitor_latency_threshold == 800
 
 def test_tunnel_rules(tmp_path):
     cfg_dir = tmp_path / "cfg"


### PR DESCRIPTION
## Summary
- Add background monitoring thread that pings the current WireGuard peer and reconnects on repeated failures or high latency
- Expose monitor intervals and thresholds through a new `[monitor]` section in `config.ini`
- Document monitoring behavior and configuration options

## Testing
- `PYTHONPATH=$PWD pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ba9bcf0d188329ad5bd8489d992971