### PR TITLE
Require qBittorrent WebUI for port updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@
 - **Server Filters**: by country (`--cc`), SecureCore (`--sc`), P2P (`--p2p`), load threshold (`--threshold`)  
 - **Fastest-by-RTT**: choose lowest-latency via ICMP (`ping`) or ProtonVPN API (`--fastest api`), or early exit under `--latency-cutoff`  
 - **NAT-PMP Port Forwarding**: `natpmpc`-based mapping & automatic lease refresh  
-- **qBittorrent-nox Integration**: sync listen-port via WebUI API or config-file fallback; resume stalled torrents  
+- **qBittorrent-nox Integration**: sync listen-port via WebUI API; resume stalled torrents
 - **Kill-Switch**: reversible iptables DROP of all non-VPN traffic (`--ks`)  
 - **Split-Tunnel**: bypass VPN for specific processes, PIDs, or IPs (`pvpn tunnel`)  
 - **Modular init**: `pvpn init [--proton|--qb|--tunnel|--network]` for targeted or full setup  
@@ -100,8 +100,10 @@ pvpn init --network   # only DNS & kill-switch defaults
 
 This will populate:
 
-- **`~/.pvpn-cli/pvpn/config.ini`**  
-- **`~/.pvpn-cli/pvpn/tunnel.json`**  
+- **`~/.pvpn-cli/pvpn/config.ini`**
+- **`~/.pvpn-cli/pvpn/tunnel.json`**
+
+If qBittorrent's WebUI was not previously enabled, `pvpn init --qb` will configure it for localhost and store your credentials. **Restart the `qbittorrent-nox` service once** after setup so the WebUI becomes active. Subsequent port changes are applied via the API without interrupting downloads. If you later disable the WebUI (`enable = false`), pvpn will warn and skip listen-port updates.
 
 ### 2. Example `config.ini`
 

--- a/pvpn/qbittorrent.py
+++ b/pvpn/qbittorrent.py
@@ -2,18 +2,15 @@
 
 """
 Manage qBittorrent-nox integration:
-- update_port: set the listening port via WebUI API or config file fallback
+- update_port: set the listening port via WebUI API
 - resume stalled torrents after restart
 """
 
 import time
 import logging
 import requests
-import subprocess
-from pathlib import Path
 
 from pvpn.config import Config
-from pvpn.utils import run_cmd, check_root
 
 # How long to wait before forcing a resume (seconds)
 RESUME_TIMEOUT = 120
@@ -21,82 +18,41 @@ POLL_INTERVAL = 5
 
 def update_port(cfg: Config, new_port: int):
     """
-    Update qBittorrent's listen port to new_port:
-      1) Attempt via WebUI API
-      2) Fallback to direct config-file edit
-      3) Resume torrents if none active after restart
+    Update qBittorrent's listen port to new_port via the WebUI API.
+    If the WebUI is disabled, log a warning and skip the update.
     """
-    if cfg.qb_enable:
-        try:
-            logging.info("Updating qBittorrent port via WebUI API")
-            session = requests.Session()
-            # Login
-            resp = session.post(
-                f"{cfg.qb_url}/api/v2/auth/login",
-                data={'username': cfg.qb_user, 'password': cfg.qb_pass},
-                timeout=10
-            )
-            resp.raise_for_status()
+    if not cfg.qb_enable:
+        logging.warning("qBittorrent WebUI disabled; skipping port update")
+        return
 
-            # Set preferences
-            prefs = {
-                'listen_port': new_port,
-                'Connection\\RandomPort': False,
-                'Connection\\UPnPNAT': False
-            }
-            r2 = session.post(
-                f"{cfg.qb_url}/api/v2/app/setPreferences",
-                json=prefs,
-                timeout=10
-            )
-            r2.raise_for_status()
-            logging.info(f"WebUI API: listen_port set to {new_port}")
-        except Exception as e:
-            logging.warning(f"WebUI API update failed: {e}")
-            _config_file_update(new_port)
-    else:
-        _config_file_update(new_port)
-
-    _resume_torrents(cfg)
-
-def _config_file_update(new_port: int):
-    """
-    Stop qbittorrent-nox, edit qBittorrent.conf, restart service.
-    """
-    logging.info("Updating qBittorrent via config-file fallback")
-    check_root()
-
-    # Stop the service
     try:
-        run_cmd("systemctl stop qbittorrent-nox", capture_output=False)
+        logging.info("Updating qBittorrent port via WebUI API")
+        session = requests.Session()
+        resp = session.post(
+            f"{cfg.qb_url}/api/v2/auth/login",
+            data={'username': cfg.qb_user, 'password': cfg.qb_pass},
+            timeout=10,
+        )
+        resp.raise_for_status()
+
+        prefs = {
+            'listen_port': new_port,
+            'random_port': False,
+            'upnp': False,
+        }
+        r2 = session.post(
+            f"{cfg.qb_url}/api/v2/app/setPreferences",
+            json=prefs,
+            timeout=10,
+        )
+        r2.raise_for_status()
+        logging.info(f"WebUI API: listen_port set to {new_port}")
+        _resume_torrents(cfg, session)
     except Exception as e:
-        logging.warning(f"Could not stop qbittorrent-nox: {e}")
+        logging.error(f"WebUI API update failed: {e}")
 
-    # Edit the config file
-    conf_path = Path.home() / ".config" / "qBittorrent" / "qBittorrent.conf"
-    if not conf_path.is_file():
-        logging.error(f"qBittorrent config not found: {conf_path}")
-    else:
-        try:
-            lines = conf_path.read_text().splitlines()
-            out = []
-            for line in lines:
-                if line.startswith("Connection\\Port="):
-                    out.append(f"Connection\\Port={new_port}")
-                else:
-                    out.append(line)
-            conf_path.write_text("\n".join(out))
-            logging.info(f"Set Connection\\Port={new_port} in {conf_path}")
-        except Exception as e:
-            logging.error(f"Failed to edit {conf_path}: {e}")
 
-    # Restart the service
-    try:
-        run_cmd("systemctl start qbittorrent-nox", capture_output=False)
-    except Exception as e:
-        logging.warning(f"Could not start qbittorrent-nox: {e}")
-
-def _resume_torrents(cfg: Config):
+def _resume_torrents(cfg: Config, session: requests.Session):
     """
     Wait up to RESUME_TIMEOUT; if no active downloads, send resumeAll via WebUI.
     """
@@ -105,21 +61,17 @@ def _resume_torrents(cfg: Config):
     while time.time() - start < RESUME_TIMEOUT:
         time.sleep(POLL_INTERVAL)
         try:
-            session = requests.Session()
             resp = session.get(f"{cfg.qb_url}/api/v2/torrents/info", timeout=10)
             resp.raise_for_status()
             torrents = resp.json()
-            # If any downloading or queued, skip resume
             if any(t.get('state') in ('downloading', 'queued') for t in torrents):
                 logging.info("Active torrents detected; not resuming")
                 return
         except Exception as e:
             logging.debug(f"Error checking torrents: {e}")
 
-    # No active downloads; resume all
     try:
-        session = requests.Session()
-        session.post(f"{cfg.qb_url}/api/v2/torrents/resumeAll", timeout=10)
+        session.post(f"{cfg.qb_url}/api/v2/torrents/resumeAll", timeout=10).raise_for_status()
         logging.info("Sent resumeAll to qBittorrent WebUI")
     except Exception as e:
         logging.error(f"Failed to resume torrents: {e}")


### PR DESCRIPTION
## Summary
- Skip qBittorrent listen-port updates when WebUI is disabled
- Configure qBittorrent WebUI during `pvpn init --qb` and hash stored credentials
- Document the one-time manual restart needed to enable the WebUI

## Testing
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68baa5c02188832997dcdd0a84f2b24c