### PR TITLE
feat: add colored icons to status output

### DIFF
--- a/pvpn/protonvpn.py
+++ b/pvpn/protonvpn.py
@@ -258,32 +258,35 @@ def disconnect(cfg: Config, args):
     print("✅ Disconnected")
 
 def status(cfg: Config):
-    """Display WireGuard, routing, and qBittorrent status."""
+    """Display WireGuard, routing, and qBittorrent status with colour and icons."""
     from pvpn.wireguard import get_active_iface, get_dns_servers
     from pvpn.routing import killswitch_status
     from pvpn.natpmp import get_public_port
     from pvpn.qbittorrent import get_listen_port
 
+    RESET = "\033[0m"
+    GREEN = "\033[92m"
+    RED = "\033[91m"
+
+    def line(label: str, ok: bool, value: str):
+        icon = "✔" if ok else "✖"
+        color = GREEN if ok else RED
+        print(f"{color}{icon}{RESET} {label:<14}: {color}{value}{RESET}")
+
     iface = get_active_iface()
-    print(f"Interface: {iface if iface else 'none'}")
+    line("Interface", bool(iface), iface if iface else "none")
 
     dns = get_dns_servers()
-    if dns:
-        print("DNS: " + ", ".join(dns))
-    else:
-        print("DNS: unknown")
+    line("DNS", bool(dns), ", ".join(dns) if dns else "unknown")
 
     ks = killswitch_status()
-    print(f"Kill-switch: {'enabled' if ks else 'disabled'}")
+    line("Kill-switch", ks, "enabled" if ks else "disabled")
 
     pub_port = get_public_port(iface, cfg.qb_port) if iface else 0
-    if pub_port:
-        print(f"Forwarded port: {pub_port}")
-    else:
-        print("Forwarded port: none")
+    line("Forwarded port", bool(pub_port), str(pub_port) if pub_port else "none")
 
     qb_port = get_listen_port(cfg)
-    print(f"qBittorrent port: {qb_port}")
+    line("qBittorrent port", bool(qb_port), str(qb_port) if qb_port else "unknown")
 
 def list_servers(cfg: Config, args):
     """

--- a/tests/test_status.py
+++ b/tests/test_status.py
@@ -1,5 +1,12 @@
+import re
 import pvpn.protonvpn as pv
 from pvpn.config import Config
+
+ANSI_RE = re.compile(r"\x1b\[[0-9;]*m")
+
+
+def strip_ansi(s: str) -> str:
+    return ANSI_RE.sub("", s)
 
 
 def test_status_reports_all(monkeypatch, capsys):
@@ -11,9 +18,9 @@ def test_status_reports_all(monkeypatch, capsys):
     monkeypatch.setattr('pvpn.qbittorrent.get_listen_port', lambda cfg: 6881)
 
     pv.status(cfg)
-    out = capsys.readouterr().out
-    assert 'Interface: wgpTEST0' in out
-    assert 'DNS: 1.1.1.1, 9.9.9.9' in out
-    assert 'Kill-switch: enabled' in out
-    assert 'Forwarded port: 12345' in out
-    assert 'qBittorrent port: 6881' in out
+    out_lines = strip_ansi(capsys.readouterr().out).splitlines()
+    assert out_lines[0].startswith('✔ Interface') and out_lines[0].endswith('wgpTEST0')
+    assert out_lines[1].startswith('✔ DNS') and out_lines[1].endswith('1.1.1.1, 9.9.9.9')
+    assert out_lines[2].startswith('✔ Kill-switch') and out_lines[2].endswith('enabled')
+    assert out_lines[3].startswith('✔ Forwarded port') and out_lines[3].endswith('12345')
+    assert out_lines[4].startswith('✔ qBittorrent port') and out_lines[4].endswith('6881')


### PR DESCRIPTION
## Summary
- improve `pvpn status` with color-coded icons for clearer interface, DNS, kill-switch, and port info
- adjust tests for new status formatting

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68baeee550908329a56cefe044ba6413