### PR TITLE
Add installation and removal scripts with docs

### DIFF
--- a/INSTALLING.md
+++ b/INSTALLING.md
@@ -1,0 +1,28 @@
+# Installing pvpn
+
+## Requirements
+- Debian Bookworm / Raspberry Pi OS
+- Root privileges (`sudo`)
+- Internet connectivity
+
+## What the installer does
+- Installs system packages: `wireguard-tools`, `iproute2`, `iptables`, `natpmpc`, `iputils-ping`, `curl`, `jq`, `ca-certificates`, and Python tools.
+- Creates a Python virtual environment under `/opt/pvpn/venv` and installs `pvpn` and its Python dependency `requests`.
+- Writes a wrapper script to `/usr/local/bin/pvpn` that launches the CLI via `python -m pvpn.cli`.
+- Installs `pvpn.service` into `/etc/systemd/system/` and enables it (not started automatically).
+- Creates the configuration directory at `/root/.pvpn-cli/pvpn` for runtime state.
+
+## Installation
+```bash
+sudo ./install.sh
+```
+After installation, configure the tool:
+```bash
+sudo pvpn init
+```
+This populates `/root/.pvpn-cli/pvpn/config.ini`.
+
+To start the VPN service after configuration:
+```bash
+sudo systemctl start pvpn.service
+```

--- a/UNINSTALLING.md
+++ b/UNINSTALLING.md
@@ -1,0 +1,16 @@
+# Uninstalling pvpn
+
+The uninstaller removes files installed by `install.sh` and optionally deletes configuration.
+
+## Removal steps
+- Stops and disables `pvpn.service`.
+- Runs `pvpn disconnect --ks false` to tear down the VPN and disable the kill-switch.
+- Removes `/usr/local/bin/pvpn`, the virtual environment `/opt/pvpn`, and the systemd unit.
+- Optionally deletes `/root/.pvpn-cli` when confirmed.
+- Cleans up `iptables` and DNS backups if present and runs a basic network health check.
+
+## Uninstall
+```bash
+sudo ./uninstall.sh
+```
+You will be prompted before configuration is deleted.

--- a/bin/pvpn
+++ b/bin/pvpn
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -e
+VENV_DIR="/opt/pvpn/venv"
+exec "$VENV_DIR/bin/python" -m pvpn.cli "$@"

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+if [[ "${EUID}" -ne 0 ]]; then
+  echo "This installer must be run as root" >&2
+  exit 1
+fi
+
+REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+INSTALL_DIR="/opt/pvpn"
+VENV_DIR="$INSTALL_DIR/venv"
+PYTHON_BIN="python3"
+
+echo "==> Installing OS packages"
+apt-get update
+apt-get install -y \
+  python3 python3-venv python3-pip \
+  wireguard-tools iproute2 iptables natpmpc \
+  iputils-ping curl jq ca-certificates >/tmp/apt.log && tail -n 20 /tmp/apt.log
+
+mkdir -p "$INSTALL_DIR"
+if [[ ! -d "$VENV_DIR" ]]; then
+  echo "==> Creating virtual environment"
+  $PYTHON_BIN -m venv "$VENV_DIR"
+fi
+
+echo "==> Installing Python dependencies"
+"$VENV_DIR/bin/pip" install --upgrade pip >/tmp/pip.log && tail -n 20 /tmp/pip.log
+"$VENV_DIR/bin/pip" install -r "$REPO_DIR/requirements.txt" >>/tmp/pip.log && tail -n 20 /tmp/pip.log
+"$VENV_DIR/bin/pip" install "$REPO_DIR" >>/tmp/pip.log && tail -n 20 /tmp/pip.log
+
+echo "==> Installing wrapper script"
+cat > /usr/local/bin/pvpn <<'WRAP'
+#!/usr/bin/env bash
+set -e
+VENV_DIR="/opt/pvpn/venv"
+exec "$VENV_DIR/bin/python" -m pvpn.cli "$@"
+WRAP
+chmod +x /usr/local/bin/pvpn
+
+echo "==> Installing systemd unit"
+install -m 644 -D "$REPO_DIR/systemd/pvpn.service" /etc/systemd/system/pvpn.service
+systemctl daemon-reload
+systemctl enable pvpn.service >/dev/null 2>&1 || true
+
+ROOT_HOME="$(getent passwd root | cut -d: -f6)"
+CONFIG_DIR="$ROOT_HOME/.pvpn-cli/pvpn"
+mkdir -p "$CONFIG_DIR"
+chown root:root "$CONFIG_DIR"
+chmod 700 "$ROOT_HOME/.pvpn-cli" "$CONFIG_DIR" 2>/dev/null || true
+
+echo "Installation complete. Configure with: sudo pvpn init"

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+if [[ "${EUID}" -ne 0 ]]; then
+  echo "This uninstaller must be run as root" >&2
+  exit 1
+fi
+
+if systemctl list-unit-files | grep -q '^pvpn.service'; then
+  echo "==> Stopping pvpn service"
+  systemctl disable --now pvpn.service >/dev/null 2>&1 || true
+fi
+
+if command -v /usr/local/bin/pvpn >/dev/null 2>&1; then
+  echo "==> Disconnecting VPN"
+  /usr/local/bin/pvpn disconnect --ks false >/dev/null 2>&1 || true
+fi
+
+rm -f /etc/systemd/system/pvpn.service
+systemctl daemon-reload
+
+rm -f /usr/local/bin/pvpn
+rm -rf /opt/pvpn
+
+ROOT_HOME="$(getent passwd root | cut -d: -f6)"
+CONFIG_BASE="$ROOT_HOME/.pvpn-cli"
+if [[ -d "$CONFIG_BASE" ]]; then
+  read -r -p "Remove configuration and state in $CONFIG_BASE? [y/N]: " ans
+  if [[ "$ans" =~ ^[Yy]$ ]]; then
+    rm -rf "$CONFIG_BASE"
+    echo "Removed $CONFIG_BASE"
+  else
+    echo "Preserved $CONFIG_BASE"
+  fi
+fi
+
+rm -f /etc/pvpn-iptables.bak /etc/resolv.conf.pvpnbak
+
+echo "==> Network health check"
+if ip route get 1.1.1.1 >/dev/null 2>&1; then
+  echo "routing: ok"
+else
+  echo "routing: check failed"
+fi
+if ping -c1 -W2 1.1.1.1 >/dev/null 2>&1; then
+  echo "ping: ok"
+else
+  echo "ping: failed"
+fi
+if getent hosts protonvpn.com >/dev/null 2>&1; then
+  echo "dns: ok"
+else
+  echo "dns: failed"
+fi
+
+echo "Uninstallation complete."


### PR DESCRIPTION
## Summary
- add install.sh to set up OS deps, Python venv, wrapper and systemd service
- add uninstall.sh to tear down service, remove files, and verify network health
- document installation and removal steps and provide a pvpn wrapper script

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bafcb80c388329ad968e08f635305d