### PR TITLE
Use Session\Port for qBittorrent listen port

### DIFF
--- a/pvpn/config.py
+++ b/pvpn/config.py
@@ -168,7 +168,9 @@ class Config:
         Ensure qBittorrent's WebUI is enabled locally with stored credentials.
         Requires a manual restart of qbittorrent-nox to take effect.
         """
-        conf_path = Path.home() / ".config" / "qBittorrent" / "qBittorrent.conf"
+        from pvpn.qbittorrent import config_path as qb_config_path
+
+        conf_path = qb_config_path()
         if not conf_path.exists():
             logging.warning(f"qBittorrent config not found: {conf_path}")
             return
@@ -190,6 +192,13 @@ class Config:
         pref['WebUI\\Username'] = self.qb_user
         if self.qb_pass:
             pref['WebUI\\Password_PBKDF2'] = self._qb_pass_hash(self.qb_pass)
+
+        # Ensure qBittorrent listens on the configured port without automatic mapping
+        pref['Session\\Port'] = str(self.qb_port)
+        pref['Connection\\UPnP'] = 'false'
+        pref['Connection\\NAT-PMP'] = 'false'
+        if 'Connection\\PortRangeMin' in pref:
+            pref.pop('Connection\\PortRangeMin')
 
         with open(conf_path, 'w') as f:
             parser.write(f)

--- a/pvpn/protonvpn.py
+++ b/pvpn/protonvpn.py
@@ -240,7 +240,7 @@ def connect(cfg: Config, args):
     while flt:
         cand = select_fastest(flt, method=method, cutoff=cutoff)
         ip = cand.get("UDP", "").split(":")[0]
-        if probe_server(ip, cfg.qb_port):
+        if probe_server(ip):
             server = cand
             break
         logging.info(f"Server {cand['Name']} lacks NAT-PMP; trying next")
@@ -339,7 +339,7 @@ def status(cfg: Config):
     ks = killswitch_status()
     line("Kill-switch", ks, "enabled" if ks else "disabled")
 
-    pub_port = get_public_port(iface, cfg.qb_port) if iface else 0
+    pub_port = get_public_port(iface) if iface else 0
     line("Forwarded port", bool(pub_port), str(pub_port) if pub_port else "none")
 
     qb_port = get_listen_port(cfg)

--- a/tests/test_status.py
+++ b/tests/test_status.py
@@ -14,7 +14,7 @@ def test_status_reports_all(monkeypatch, capsys):
     monkeypatch.setattr('pvpn.wireguard.get_active_iface', lambda: 'wgpTEST0')
     monkeypatch.setattr('pvpn.wireguard.get_dns_servers', lambda: ['1.1.1.1', '9.9.9.9'])
     monkeypatch.setattr('pvpn.routing.killswitch_status', lambda: True)
-    monkeypatch.setattr('pvpn.natpmp.get_public_port', lambda iface, port: 12345)
+    monkeypatch.setattr('pvpn.natpmp.get_public_port', lambda iface: 12345)
     monkeypatch.setattr('pvpn.qbittorrent.get_listen_port', lambda cfg: 6881)
 
     pv.status(cfg)

--- a/tests/test_wireguard_ipv6.py
+++ b/tests/test_wireguard_ipv6.py
@@ -1,0 +1,16 @@
+import pvpn.wireguard as wg
+
+
+def test_adds_ipv6(tmp_path):
+    conf = tmp_path / 'wg.conf'
+    conf.write_text('[Interface]\nAllowedIPs = 0.0.0.0/0\n')
+    wg.ensure_ipv6_allowed(str(conf))
+    assert 'AllowedIPs = 0.0.0.0/0, ::/0' in conf.read_text()
+
+
+def test_no_duplicate(tmp_path):
+    conf = tmp_path / 'wg.conf'
+    conf.write_text('[Interface]\nAllowedIPs = 0.0.0.0/0, ::/0\n')
+    wg.ensure_ipv6_allowed(str(conf))
+    content = conf.read_text()
+    assert content.count('::/0') == 1


### PR DESCRIPTION
## Summary
- prefer qBittorrent's `Session\Port` when reading config
- disable NAT-PMP via API and config when updating qBittorrent
- ensure WebUI setup writes `Session\Port` and removes legacy `PortRangeMin`
- request ProtonVPN's forwarded port via NAT-PMP and keep the lease refreshed
- patch WireGuard configs so `AllowedIPs` include `::/0` for IPv6 routing
- detect qBittorrent.conf in `~/qbprofile/qBittorrent/config` or via `--profile` argument

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bd7fe206d483298b18b7080bfa6399